### PR TITLE
19 - Backend Schemas

### DIFF
--- a/packages/backend/src/auth.ts
+++ b/packages/backend/src/auth.ts
@@ -1,0 +1,38 @@
+// Auth utilities
+import * as bcrypt from "bcrypt";
+import * as jwt from "jsonwebtoken";
+
+import type { User, UserWithId } from "./models/user";
+
+export async function isPasswordValid(user: User, password: string): Promise<boolean> {
+    return await bcrypt.compare(password, user.password);
+}
+
+const jwtSecret = process.env.JWT_SECRET;
+if (!jwtSecret) {
+    throw new Error("JWT_SECRET is not set");
+}
+
+const jwtExpiryTime = "30m";
+
+type JWTData = { _id: UserWithId["_id"]; };
+
+export function generateJWT(user: UserWithId): string {
+    return jwt.sign({ _id: user._id }, jwtSecret as string, { expiresIn: jwtExpiryTime })
+}
+
+export function verifyJWT(token: string): JWTData | null {
+    try {
+        return jwt.verify(token, jwtSecret as string) as JWTData;
+    } catch (err) {
+        return null;
+    }
+}
+
+declare global {
+    namespace Express {
+        interface Request {
+            _id?: JWTData["_id"];
+        }
+    }
+}

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -1,7 +1,11 @@
 import express, { NextFunction, Request, Response } from "express";
 import mongoose from "mongoose";
 import cors from "cors";
-import { createUser, findUserByName, generateJWT, isPasswordValid, verifyJWT } from "./services/user";
+
+import { createUser, findUserByName } from "./services/user";
+import { generateJWT, isPasswordValid, verifyJWT } from "./auth";
+import { createStore, findStoreByName } from "./services/store";
+import { createPost } from "./services/post";
 
 mongoose.set("debug", true);
 mongoose.connect(`${process.env.MONGO_CONNECTION_STRING}/MainDatabase`).catch((err) => {
@@ -102,5 +106,38 @@ app.get("/testNeedsAuth", authMiddleware, async (req, res) => {
 });
 
 app.listen(port, async () => {
+    // const store = await createStore({
+    //     name: "Test Store",
+    //     description: "This is a test store.",
+    //     address: "123 Test St, Test City, TC 12345",
+    //     phoneNumber: "123-456-7890",
+    //     websiteUrl: "https://example.com",
+    //     createdAt: new Date(),
+    // });
+
+    const targetUser = await findUserByName("foo");
+    if (!targetUser) {
+        console.error("Target user not found");
+        return;
+    }
+
+    // console.log(store.name, "created with ID:", store._id);
+
+    // const post = await createPost({
+    //     author: targetUser._id,
+    //     mainImageUrl: "https://example.com/image.jpg",
+    //     description: "This is a test post.",
+    //     comments: [
+    //         {
+    //             author: targetUser._id,
+    //             content: "This is a test comment.",
+    //             createdAt: new Date(),
+    //         }
+    //     ],
+    //     createdAt: new Date(),
+    // })
+
+    console.log(targetUser.posts);
+
     console.log(`Example app listening at http://localhost:${port}`);
 });

--- a/packages/backend/src/backend.ts
+++ b/packages/backend/src/backend.ts
@@ -4,8 +4,6 @@ import cors from "cors";
 
 import { createUser, findUserByName } from "./services/user";
 import { generateJWT, isPasswordValid, verifyJWT } from "./auth";
-import { createStore, findStoreByName } from "./services/store";
-import { createPost } from "./services/post";
 
 mongoose.set("debug", true);
 mongoose.connect(`${process.env.MONGO_CONNECTION_STRING}/MainDatabase`).catch((err) => {
@@ -106,38 +104,5 @@ app.get("/testNeedsAuth", authMiddleware, async (req, res) => {
 });
 
 app.listen(port, async () => {
-    // const store = await createStore({
-    //     name: "Test Store",
-    //     description: "This is a test store.",
-    //     address: "123 Test St, Test City, TC 12345",
-    //     phoneNumber: "123-456-7890",
-    //     websiteUrl: "https://example.com",
-    //     createdAt: new Date(),
-    // });
-
-    const targetUser = await findUserByName("foo");
-    if (!targetUser) {
-        console.error("Target user not found");
-        return;
-    }
-
-    // console.log(store.name, "created with ID:", store._id);
-
-    // const post = await createPost({
-    //     author: targetUser._id,
-    //     mainImageUrl: "https://example.com/image.jpg",
-    //     description: "This is a test post.",
-    //     comments: [
-    //         {
-    //             author: targetUser._id,
-    //             content: "This is a test comment.",
-    //             createdAt: new Date(),
-    //         }
-    //     ],
-    //     createdAt: new Date(),
-    // })
-
-    console.log(targetUser.posts);
-
     console.log(`Example app listening at http://localhost:${port}`);
 });

--- a/packages/backend/src/models/post.ts
+++ b/packages/backend/src/models/post.ts
@@ -1,0 +1,54 @@
+import mongoose, { type ObjectId } from "mongoose";
+import { User } from "./user";
+
+const commentSchema = new mongoose.Schema({
+    author: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    content: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now },
+});
+
+export type CommentUnresolved = {
+    author: ObjectId;
+    content: string;
+    createdAt: Date;
+}
+
+export type Comment = {
+    author: User;
+    content: string;
+    createdAt: Date;
+}
+
+const postSchema = new mongoose.Schema({
+    author: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+
+    mainImageUrl: { type: String, required: true },
+    description: { type: String, required: true },
+    comments: { type: [commentSchema], default: [] },
+
+    createdAt: { type: Date, default: Date.now },
+});
+
+export type PostUnresolved = {
+    author: ObjectId;
+
+    mainImageUrl: string;
+    description: string;
+    comments: CommentUnresolved[];
+
+    createdAt: Date;
+}
+
+export type Post = {
+    author: User;
+
+    mainImageUrl: string;
+    description: string;
+    comments: Comment[];
+
+    createdAt: Date;
+};
+
+export type PostWithId = Post & { _id: ObjectId };
+
+export const Post = mongoose.model("Post", postSchema, "Posts");

--- a/packages/backend/src/models/store.ts
+++ b/packages/backend/src/models/store.ts
@@ -1,0 +1,28 @@
+import mongoose, { type ObjectId } from "mongoose";
+
+const storeSchema = new mongoose.Schema({
+    name: { type: String, required: true, unique: true },
+    description: { type: String, required: false },
+
+    websiteUrl: { type: String, required: false },
+    phoneNumber: { type: String, required: false },
+    address: { type: String, required: false },
+
+    createdAt: { type: Date, default: Date.now },
+});
+
+export type Store = {
+    name: string;
+
+    description?: string;
+    websiteUrl?: string;
+
+    phoneNumber?: string;
+    address?: string;
+
+    createdAt: Date;
+};
+
+export type StoreWithId = Store & { _id: ObjectId };
+
+export const Store = mongoose.model("Store", storeSchema, "Stores");

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -1,13 +1,9 @@
 import mongoose, { type ObjectId } from "mongoose";
 import bcrypt from "bcrypt";
-import { Post, PostUnresolved } from "./post";
 
 const userSchema = new mongoose.Schema({
     username: { type: String, required: true, unique: true },
     password: { type: String, required: true },
-
-    posts: [{ type: mongoose.Schema.Types.ObjectId, ref: "Post", default: [] }],
-
     createdAt: { type: Date, default: Date.now },
 });
 
@@ -21,21 +17,9 @@ userSchema.pre("save", async function (next) {
     next();
 });
 
-export type UserUnresolved = {
-    username: string;
-    password: string;
-
-    posts: PostUnresolved[];
-
-    createdAt: Date;
-};
-
 export type User = {
     username: string;
     password: string;
-
-    posts: Post[];
-
     createdAt: Date;
 };
 

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -1,9 +1,13 @@
 import mongoose, { type ObjectId } from "mongoose";
 import bcrypt from "bcrypt";
+import { Post, PostUnresolved } from "./post";
 
 const userSchema = new mongoose.Schema({
     username: { type: String, required: true, unique: true },
     password: { type: String, required: true },
+
+    posts: [{ type: mongoose.Schema.Types.ObjectId, ref: "Post", default: [] }],
+
     createdAt: { type: Date, default: Date.now },
 });
 
@@ -17,9 +21,21 @@ userSchema.pre("save", async function (next) {
     next();
 });
 
+export type UserUnresolved = {
+    username: string;
+    password: string;
+
+    posts: PostUnresolved[];
+
+    createdAt: Date;
+};
+
 export type User = {
     username: string;
     password: string;
+
+    posts: Post[];
+
     createdAt: Date;
 };
 

--- a/packages/backend/src/services/post.ts
+++ b/packages/backend/src/services/post.ts
@@ -1,0 +1,24 @@
+import { ObjectId } from "mongoose";
+import { Post, PostUnresolved, PostWithId } from "../models/post";
+
+export async function findAllPosts(): Promise<PostWithId[]> {
+    // @ts-ignore: .populate doesn't properly manipulate the type.
+    return Post.find().populate("author").populate("comments.author") as PostWithId[];
+}
+
+export async function findPostById(id: string): Promise<PostWithId | null> {
+    // @ts-ignore: .populate doesn't properly manipulate the type.
+    return Post.findById(id)?.populate("author")?.populate("comments.author") as PostWithId | null;
+}
+
+export async function findPostsByAuthor(author: ObjectId): Promise<PostWithId | null> {
+    // @ts-ignore: .populate doesn't properly manipulate the type.
+    return Post.find({ author }).populate("author").populate("comments.author") as PostWithId | null;
+}
+
+export async function createPost(info: PostUnresolved): Promise<PostWithId> {
+    const post = new Post(info);
+
+    // @ts-ignore: .save() doesn't add _id to the type.
+    return await post.save();
+}

--- a/packages/backend/src/services/post.ts
+++ b/packages/backend/src/services/post.ts
@@ -11,7 +11,7 @@ export async function findPostById(id: string): Promise<PostWithId | null> {
     return Post.findById(id)?.populate("author")?.populate("comments.author") as PostWithId | null;
 }
 
-export async function findPostsByAuthor(author: ObjectId): Promise<PostWithId | null> {
+export async function findPostsByAuthor(author: ObjectId): Promise<PostWithId[] | null> {
     // @ts-ignore: .populate doesn't properly manipulate the type.
     return Post.find({ author }).populate("author").populate("comments.author") as PostWithId | null;
 }

--- a/packages/backend/src/services/store.ts
+++ b/packages/backend/src/services/store.ts
@@ -1,0 +1,20 @@
+import { Store, type StoreWithId } from "../models/store";
+
+export async function findAllStores(): Promise<StoreWithId[]> {
+    return Store.find();
+}
+
+export async function findStoreById(id: string): Promise<StoreWithId | null> {
+    return Store.findById(id);
+}
+
+export async function findStoreByName(name: string): Promise<StoreWithId | null> {
+    return Store.findOne({ name });
+}
+
+export async function createStore(info: Store): Promise<StoreWithId> {
+    const store = new Store(info);
+
+    // @ts-ignore: .save() doesn't add _id to the type.
+    return await store.save();
+}

--- a/packages/backend/src/services/user.ts
+++ b/packages/backend/src/services/user.ts
@@ -1,54 +1,18 @@
 import { User, UserWithId } from "../models/user";
-import * as bcrypt from "bcrypt";
-import * as jwt from "jsonwebtoken";
 
 export async function findAllUsers(): Promise<UserWithId[]> {
-    return User.find();
+    // @ts-ignore: .populate doesn't properly manipulate the type.
+    return User.find().populate("posts.author").populate("posts.comments.author") as UserWithId[];
 }
 
 export async function findUserByName(username: string): Promise<UserWithId | null> {
-    return User.findOne({ username });
+    // @ts-ignore: .populate doesn't properly manipulate the type.
+    return User.findOne({ username }).populate("posts.author").populate("posts.comments.author") as UserWithId | null;
 }
 
 export async function createUser(username: string, password: string): Promise<UserWithId> {
     const user = new User({ username, password });
 
-    // @ts-ignore: Not sure why their typings don't include _id.
-    // But from my tests, it is included.
+    // @ts-ignore: .save() doesn't add _id to the type.
     return await user.save();
-}
-
-// Auth utilities
-
-export async function isPasswordValid(user: User, password: string): Promise<boolean> {
-    return await bcrypt.compare(password, user.password);
-}
-
-const jwtSecret = process.env.JWT_SECRET;
-if (!jwtSecret) {
-    throw new Error("JWT_SECRET is not set");
-}
-
-const jwtExpiryTime = "30m";
-
-type JWTData = { _id: UserWithId["_id"]; };
-
-export function generateJWT(user: UserWithId): string {
-    return jwt.sign({ _id: user._id }, jwtSecret as string, { expiresIn: jwtExpiryTime })
-}
-
-export function verifyJWT(token: string): JWTData | null {
-    try {
-        return jwt.verify(token, jwtSecret as string) as JWTData;
-    } catch (err) {
-        return null;
-    }
-}
-
-declare global {
-    namespace Express {
-        interface Request {
-            _id?: JWTData["_id"];
-        }
-    }
 }

--- a/packages/backend/src/services/user.ts
+++ b/packages/backend/src/services/user.ts
@@ -1,13 +1,11 @@
 import { User, UserWithId } from "../models/user";
 
 export async function findAllUsers(): Promise<UserWithId[]> {
-    // @ts-ignore: .populate doesn't properly manipulate the type.
-    return User.find().populate("posts.author").populate("posts.comments.author") as UserWithId[];
+    return User.find();
 }
 
 export async function findUserByName(username: string): Promise<UserWithId | null> {
-    // @ts-ignore: .populate doesn't properly manipulate the type.
-    return User.findOne({ username }).populate("posts.author").populate("posts.comments.author") as UserWithId | null;
+    return User.findOne({ username });
 }
 
 export async function createUser(username: string, password: string): Promise<UserWithId> {


### PR DESCRIPTION
This brings the schemas for `Post`s and `Store`s instead of just having a `User` schema.

The functions provided by the services automatically populate references, so when searching by posts, you get resolved authors and comment authors instead of just references to them.

This wouldn't scale, but should be fine for our cases of a smaller demo app.

Partially resolves #19, there are demo schemas and some entries in the collections now, but not enough to be useful to the frontend, and we might want to add more data.