### PR TITLE
36 - Frontend Testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,3 +26,6 @@ jobs:
 
             - name: Run Backend Tests
               run: npm run -w backend test
+
+            - name: Run Frontend Tests
+              run: npm run -w frontend test

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "frontend:dev": "npm run -w frontend dev",
     "backend:dev": "npm run -w backend dev",
+    "frontend:test": "npm run -w frontend test",
+    "backend:test": "npm run -w backend test",
     "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc",
-  "build": "npm run -w frontend build",
-  "postbuild": "rm -rf packages/frontend/dist && cp -r packages/frontend/.next packages/frontend/dist"
+    "build": "npm run -w frontend build",
+    "postbuild": "rm -rf packages/frontend/dist && cp -r packages/frontend/.next packages/frontend/dist"
   },
   "author": "",
   "license": "ISC",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -32,6 +33,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4.5.1",
     "@vitest/browser": "^3.2.1",
+    "@vitest/coverage-v8": "^3.2.1",
     "eslint": "^9.26.0",
     "eslint-config-next": "15.3.1",
     "eslint-plugin-react": "^7.37.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,6 +24,8 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.26.0",
     "@tailwindcss/postcss": "^4.1.6",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.3.0",
     "@types/mongoose": "^5.11.96",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -36,8 +38,12 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.1.0",
+    "jsdom": "^26.1.0",
+    "playwright": "^1.52.0",
+    "resize-observer-polyfill": "^1.5.1",
     "tailwindcss": "^4.1.4",
     "typescript": "^5",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.1",
     "vitest-browser-react": "^0.2.0"
   }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest --run"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -27,6 +28,8 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4.5.1",
+    "@vitest/browser": "^3.2.1",
     "eslint": "^9.26.0",
     "eslint-config-next": "15.3.1",
     "eslint-plugin-react": "^7.37.5",
@@ -34,6 +37,8 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.1.0",
     "tailwindcss": "^4.1.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.1",
+    "vitest-browser-react": "^0.2.0"
   }
 }

--- a/packages/frontend/tests/navbar.test.tsx
+++ b/packages/frontend/tests/navbar.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Navbar from '@/components/navbar';
+
+it("should render the HAUL text", async () => {
+    render(<Navbar />);
+
+    const textElement = screen.getByText("HAUL");
+    expect(textElement).toBeDefined();
+});

--- a/packages/frontend/tests/navbar.test.tsx
+++ b/packages/frontend/tests/navbar.test.tsx
@@ -1,11 +1,303 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
 
 import Navbar from '@/components/navbar';
 
-it("should render the HAUL text", async () => {
+// Mock Next.js navigation hook
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(),
+}));
+
+// Mock window.location
+const mockLocation = {
+  href: '',
+};
+Object.defineProperty(window, 'location', {
+  value: mockLocation,
+  writable: true,
+});
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    // Reset localStorage mock
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+    
+    // Reset pathname mock
+    (usePathname as any).mockReturnValue('/');
+    
+    // Reset location mock
+    mockLocation.href = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("should render the HAUL text", async () => {
+      render(<Navbar />);
+
+      const textElement = screen.getByText("HAUL");
+      expect(textElement).toBeDefined();
+  });
+
+  it("should render all navigation links when not logged in", async () => {
+      render(<Navbar />);
+
+      // Check for HAUL logo/link
+      expect(screen.queryByText('HAUL')).not.toBeNull()
+
+      // Check for Login button when not logged in
+      expect(screen.queryByText('Login')).not.toBeNull()
+  });
+
+  it("should render all navigation links when logged in", async () => {
+      // Mock localStorage to simulate logged in user
+      Object.defineProperty(window, 'localStorage', {
+          value: {
+              getItem: (key: string) => {
+                  if (key === 'user') {
+                      return JSON.stringify({ username: 'testuser' });
+                  }
+                  return null;
+              },
+              setItem: () => {},
+              removeItem: () => {},
+          },
+          writable: true
+      });
+
+      render(<Navbar />);
+
+      // Check for HAUL logo/link
+      const haulLink = screen.getByText("HAUL");
+      expect(haulLink).toBeDefined();
+
+      // Check for navigation links (visible on desktop)
+      const trendsLink = screen.getByText("TRENDS");
+      expect(trendsLink).toBeDefined();
+
+      const findsLink = screen.getByText("FINDS");
+      expect(findsLink).toBeDefined();
+
+      const storesLink = screen.getByText("STORES");
+      expect(storesLink).toBeDefined();
+
+      const profileLink = screen.getByText("PROFILE");
+      expect(profileLink).toBeDefined();
+
+      // Check for welcome message and logout button
+      const welcomeMessage = screen.getByText("Welcome, testuser");
+      expect(welcomeMessage).toBeDefined();
+
+      const logoutButton = screen.getByText("Logout");
+      expect(logoutButton).toBeDefined();
+  });
+
+  it("should handle storage events and update user info", async () => {
+    const mockGetItem = vi.fn();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: mockGetItem,
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+
+    // Initially no user
+    mockGetItem.mockReturnValue(null);
+    
+    render(<Navbar />);
+    
+    // Verify login button is shown initially
+    expect(screen.queryByText('Login')).not.toBeNull();
+
+    // Simulate user login via storage event
+    mockGetItem.mockReturnValue(JSON.stringify({ username: 'newuser' }));
+    
+    const storageEvent = new StorageEvent('storage', {
+      key: 'user',
+      newValue: JSON.stringify({ username: 'newuser' }),
+    });
+    
+    fireEvent(window, storageEvent);
+    
+    await waitFor(() => {
+      expect(screen.queryByText('Welcome, newuser')).not.toBeNull();
+    });
+  });
+
+  it("should handle userLogin custom events", async () => {
+    const mockGetItem = vi.fn();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: mockGetItem,
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+
+    // Initially no user
+    mockGetItem.mockReturnValue(null);
+    
     render(<Navbar />);
 
-    const textElement = screen.getByText("HAUL");
-    expect(textElement).toBeDefined();
+    // Simulate user login via custom event
+    mockGetItem.mockReturnValue(JSON.stringify({ username: 'eventuser' }));
+    
+    const loginEvent = new Event('userLogin');
+    fireEvent(window, loginEvent);
+    
+    await waitFor(() => {
+      expect(screen.queryByText('Welcome, eventuser')).not.toBeNull();
+    });
+  });
+
+  it("should ignore storage events for other keys", async () => {
+    const mockGetItem = vi.fn().mockReturnValue(null);
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: mockGetItem,
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+    
+    render(<Navbar />);
+    
+    // Simulate storage event for different key
+    const storageEvent = new StorageEvent('storage', {
+      key: 'otherKey',
+      newValue: 'someValue',
+    });
+    
+    fireEvent(window, storageEvent);
+    
+    // Should not call getItem for user info update
+    expect(mockGetItem).toHaveBeenCalledTimes(1); // Only initial call
+  });
+
+  it("should handle logout correctly", async () => {
+    const mockRemoveItem = vi.fn();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => JSON.stringify({ username: 'testuser' }),
+        setItem: vi.fn(),
+        removeItem: mockRemoveItem,
+      },
+      writable: true
+    });
+
+    render(<Navbar />);
+
+    const logoutButton = screen.getByText("Logout");
+    fireEvent.click(logoutButton);
+
+    expect(mockRemoveItem).toHaveBeenCalledWith('authToken');
+    expect(mockRemoveItem).toHaveBeenCalledWith('user');
+    expect(mockLocation.href).toBe('/login');
+  });
+
+  it("should highlight active navigation link based on pathname", async () => {
+    // Mock pathname to be on trends page
+    (usePathname as any).mockReturnValue('/trends');
+    
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => JSON.stringify({ username: 'testuser' }),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+
+    render(<Navbar />);
+
+    const trendsLink = screen.getByText("TRENDS");
+    expect(trendsLink.className).toContain('font-bold');
+
+    const findsLink = screen.getByText("FINDS");
+    expect(findsLink.className).toContain('font-normal');
+  });
+
+  it("should render mobile menu when screen is small", async () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => JSON.stringify({ username: 'testuser' }),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+
+    render(<Navbar />);
+
+    // Mobile menu should be present (even if hidden by CSS)
+    const menuButton = screen.getByRole('button', { name: '' }); // IoMenu button
+    expect(menuButton).toBeDefined();
+  });
+
+  it("should clean up event listeners on unmount", async () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(<Navbar />);
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+    expect(addEventListenerSpy).toHaveBeenCalledWith('userLogin', expect.any(Function));
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('userLogin', expect.any(Function));
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it("should update user info when localStorage has invalid JSON", async () => {
+    const mockGetItem = vi.fn();
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: mockGetItem,
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+
+    // Return invalid JSON
+    mockGetItem.mockReturnValue('invalid json');
+    
+    // Should throw when parsing invalid JSON
+    expect(() => render(<Navbar />)).toThrow();
+  });
+
+  it("should handle localStorage getItem returning null initially", async () => {
+    const mockGetItem = vi.fn().mockReturnValue(null);
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: mockGetItem,
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true
+    });
+    
+    render(<Navbar />);
+    
+    expect(screen.queryByText('Login')).not.toBeNull();
+    expect(screen.queryByText('Welcome,')).toBeNull();
+  });
 });

--- a/packages/frontend/tests/what.test.tsx
+++ b/packages/frontend/tests/what.test.tsx
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("test", () => {
+    it("should pass", () => {
+        expect(true).toBe(true);
+    });
+});

--- a/packages/frontend/tests/what.test.tsx
+++ b/packages/frontend/tests/what.test.tsx
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("test", () => {
-    it("should pass", () => {
-        expect(true).toBe(true);
-    });
-});

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
     environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts'],
+    setupFiles: ['./vitest.setup.ts']
   },
   resolve: {
     alias: {

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+// https://nextjs.org/docs/app/guides/testing/vitest
+
+export default defineConfig({
+  plugins: [tsconfigPaths(), react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+})

--- a/packages/frontend/vitest.setup.ts
+++ b/packages/frontend/vitest.setup.ts
@@ -1,0 +1,4 @@
+// Need this polyfill for headlessui
+import ResizeObserver from 'resize-observer-polyfill'
+
+global.ResizeObserver = ResizeObserver


### PR DESCRIPTION
Resolves #36 

Uses [`Vitest`](https://vitest.dev/guide) and [`JSDom`](https://github.com/jsdom/jsdom) to emulate a browser and test the Navbar component (fulfills the criteria of #36, with several buttons and interactivity via localStorage)

- Adds `frontend:test` and `backend:test`
- Adds `test` and `coverage` commands to frontend

![image](https://github.com/user-attachments/assets/5ecb5748-7044-462e-b1bd-602c5a5a6cb5)
